### PR TITLE
02. Adapter - 사이에 끼워 재사용한다

### DIFF
--- a/src/main/java/example/_02_adapter/Banner.java
+++ b/src/main/java/example/_02_adapter/Banner.java
@@ -1,0 +1,21 @@
+package example._02_adapter;
+
+class Banner {
+    private final String str;
+
+    public Banner(String str) {
+        this.str = str;
+    }
+
+    public void showWithParen() {
+        show("(", ")");
+    }
+
+    public void showWithAster() {
+        show("*", "*");
+    }
+
+    private void show(String open, String close) {
+        System.out.printf("%s%s%s", open, str, close);
+    }
+}

--- a/src/main/java/example/_02_adapter/Main.java
+++ b/src/main/java/example/_02_adapter/Main.java
@@ -1,0 +1,9 @@
+package example._02_adapter;
+
+class Main {
+    public static void main(String[] args) {
+        Print p = new PrintBanner("Hello");
+        p.printWeak();
+        p.printStrong();
+    }
+}

--- a/src/main/java/example/_02_adapter/Print.java
+++ b/src/main/java/example/_02_adapter/Print.java
@@ -1,7 +1,7 @@
 package example._02_adapter;
 
-interface Print {
-    void printWeak();
+abstract class Print {
+    abstract void printWeak();
 
-    void printStrong();
+    abstract void printStrong();
 }

--- a/src/main/java/example/_02_adapter/Print.java
+++ b/src/main/java/example/_02_adapter/Print.java
@@ -1,0 +1,7 @@
+package example._02_adapter;
+
+interface Print {
+    void printWeak();
+
+    void printStrong();
+}

--- a/src/main/java/example/_02_adapter/PrintBanner.java
+++ b/src/main/java/example/_02_adapter/PrintBanner.java
@@ -1,17 +1,19 @@
 package example._02_adapter;
 
-class PrintBanner extends Banner implements Print {
+class PrintBanner extends Print {
+    private final Banner banner;
+
     public PrintBanner(String str) {
-        super(str);
+        this.banner = new Banner(str);
     }
 
     @Override
     public void printWeak() {
-        super.showWithParen();
+        banner.showWithParen();
     }
 
     @Override
     public void printStrong() {
-        super.showWithAster();
+        banner.showWithAster();
     }
 }

--- a/src/main/java/example/_02_adapter/PrintBanner.java
+++ b/src/main/java/example/_02_adapter/PrintBanner.java
@@ -1,0 +1,17 @@
+package example._02_adapter;
+
+class PrintBanner extends Banner implements Print {
+    public PrintBanner(String str) {
+        super(str);
+    }
+
+    @Override
+    public void printWeak() {
+        super.showWithParen();
+    }
+
+    @Override
+    public void printStrong() {
+        super.showWithAster();
+    }
+}

--- a/src/test/java/example/_02_adapter/MainTest.java
+++ b/src/test/java/example/_02_adapter/MainTest.java
@@ -1,0 +1,24 @@
+package example._02_adapter;
+
+import example.MainMethodTest;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MainTest extends MainMethodTest {
+
+    @Test
+    void outputPrint() {
+        //when
+        runMain();
+
+        //then
+        assertThat(output()).contains("(Hello)", "*Hello*");
+    }
+
+
+    @Override
+    protected void runMain(String... args) {
+        Main.main(args);
+    }
+}


### PR DESCRIPTION
> 📚
> `이미 제공된 것`과 `필요한 것` 사이의 **차이**를 메우는 디자인 패턴

### 클래스 다이어그램

<img width="740" alt="image" src="https://user-images.githubusercontent.com/75404713/211790709-399f2bb9-208b-4a74-a868-c4388637c593.png">


### 메모

- Adapter 패턴은 신버전과 구버전을 공존시키고, 유지 보수까지 편하게 하도록 도와준다 p.67


### 관련 패턴

- Bridge 패턴 - Adapter는 인터페이스(API)가 서로 다른 클래스를 연결, Bridge는 기능-구현 계층을 연결
- Decorator 패턴 - Adapter는 인터페이스(API) 차이를 메우는 패턴, Decorator는 인터페이스(API)를 변경하지 않고 기능 추가하는 패턴
  -  🤔Adapter도 인터페이스 변경 없지 않나?,,, 


---

### 사례

- Tomcat의 [CoyoteAdapter](https://github.com/apache/tomcat/blob/510f0b6a0e8e20d1db173e95a64afd207b44b517/java/org/apache/catalina/connector/CoyoteAdapter.java#L310)  -> HTTP 요청을 [HttpServletRequest](https://github.com/apache/tomcat/blob/510f0b6a0e8e20d1db173e95a64afd207b44b517/java/org/apache/catalina/connector/Request.java#L128)로 변환
  - tomcat에는 catalina와 coyote 패키지가 포함되어있는데, catalina는 서블릿, 서블릿 컨테이너를 구현한 패키지고 coyote는 http 프로토콜을 구현한 패키지인 느낌이다
  - 그래서 coyote 패키지의 request, response는 low-level에 대한 구현체이므로 catalina 패키지에서 CoyoteAdapter를 통해 coyote 패키지의 request를 catalina 패키지의 request(HttpServletRequest impl)로 변경하는 것 같다
  - CoyoteAdapter는 형변환을 사용한다
  - 책 예제와 완벽하게 동일한 구조는 아니나 사용 의도는 같은 것 같다

<img width="753" alt="image" src="https://github.com/viiviii/java-learning-design-patterns/assets/75404713/3b1b6a35-00db-4c23-8def-1f04b3e4fb4e">
