### PR TITLE
05. Singleton - 인스턴스를 단 하나만 만든다

### DIFF
--- a/src/main/java/example/_05_singleton/Main.java
+++ b/src/main/java/example/_05_singleton/Main.java
@@ -1,0 +1,15 @@
+package example._05_singleton;
+
+class Main {
+    public static void main(String[] args) {
+        System.out.println("Start.");
+        Singleton obj1 = Singleton.getInstance();
+        Singleton obj2 = Singleton.getInstance();
+        if (obj1 == obj2) {
+            System.out.println("obj1과 obj2는 같은 인스턴스입니다.");
+        } else {
+            System.out.println("obj1과 obj2는 같은 인스턴스가 아닙니다.");
+        }
+        System.out.println("End.");
+    }
+}

--- a/src/main/java/example/_05_singleton/Singleton.java
+++ b/src/main/java/example/_05_singleton/Singleton.java
@@ -1,12 +1,12 @@
 package example._05_singleton;
 
-class Singleton {
-    private static final Singleton instance = new Singleton();
+final class Singleton {
+    private static final Singleton INSTANCE = new Singleton();
 
     private Singleton() {
     }
 
     public static Singleton getInstance() {
-        return instance;
+        return INSTANCE;
     }
 }

--- a/src/main/java/example/_05_singleton/Singleton.java
+++ b/src/main/java/example/_05_singleton/Singleton.java
@@ -1,0 +1,12 @@
+package example._05_singleton;
+
+class Singleton {
+    private static final Singleton instance = new Singleton();
+
+    private Singleton() {
+    }
+
+    public static Singleton getInstance() {
+        return instance;
+    }
+}

--- a/src/main/java/example/_05_singleton/TicketMaker.java
+++ b/src/main/java/example/_05_singleton/TicketMaker.java
@@ -2,7 +2,7 @@ package example._05_singleton;
 
 class TicketMaker {
     private static final TicketMaker instance = new TicketMaker();
-    
+
     private int ticket = 1000;
 
     private TicketMaker() {
@@ -12,7 +12,7 @@ class TicketMaker {
         return instance;
     }
 
-    public int getNextTicketNumber() {
+    public synchronized int getNextTicketNumber() {
         return ticket++;
     }
 }

--- a/src/main/java/example/_05_singleton/TicketMaker.java
+++ b/src/main/java/example/_05_singleton/TicketMaker.java
@@ -1,7 +1,7 @@
 package example._05_singleton;
 
-class TicketMaker {
-    private static final TicketMaker instance = new TicketMaker();
+final class TicketMaker {
+    private static final TicketMaker INSTANCE = new TicketMaker();
 
     private int ticket = 1000;
 
@@ -9,7 +9,7 @@ class TicketMaker {
     }
 
     public static TicketMaker getInstance() {
-        return instance;
+        return INSTANCE;
     }
 
     public synchronized int getNextTicketNumber() {

--- a/src/main/java/example/_05_singleton/TicketMaker.java
+++ b/src/main/java/example/_05_singleton/TicketMaker.java
@@ -1,0 +1,18 @@
+package example._05_singleton;
+
+class TicketMaker {
+    private static final TicketMaker instance = new TicketMaker();
+    
+    private int ticket = 1000;
+
+    private TicketMaker() {
+    }
+
+    public static TicketMaker getInstance() {
+        return instance;
+    }
+
+    public int getNextTicketNumber() {
+        return ticket++;
+    }
+}

--- a/src/main/java/example/_05_singleton/Triple.java
+++ b/src/main/java/example/_05_singleton/Triple.java
@@ -1,0 +1,9 @@
+package example._05_singleton;
+
+enum Triple {
+    ALPHA, BETA, GAMMA;
+
+    public static Triple getInstance(String name) {
+        return Triple.valueOf(name);
+    }
+}

--- a/src/test/java/example/_05_singleton/MainTest.java
+++ b/src/test/java/example/_05_singleton/MainTest.java
@@ -1,0 +1,23 @@
+package example._05_singleton;
+
+import example.MainMethodTest;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MainTest extends MainMethodTest {
+
+    @Test
+    void outputSameInstance() {
+        //when
+        runMain();
+
+        //then
+        assertThat(output()).contains("obj1과 obj2는 같은 인스턴스입니다.");
+    }
+
+    @Override
+    protected void runMain(String... args) {
+        Main.main(args);
+    }
+}

--- a/src/test/java/example/_05_singleton/SingletonTest.java
+++ b/src/test/java/example/_05_singleton/SingletonTest.java
@@ -1,0 +1,27 @@
+package example._05_singleton;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SingletonTest {
+
+    @Test
+    void sameInstance() {
+        //given
+        var obj1 = Singleton.getInstance();
+        var obj2 = Singleton.getInstance();
+
+        //then
+        assertThat(obj1).isSameAs(obj2);
+    }
+
+    @Test
+    void instanceNotNull() {
+        //given
+        var obj1 = Singleton.getInstance();
+
+        //then
+        assertThat(obj1).isNotNull();
+    }
+}

--- a/src/test/java/example/_05_singleton/TicketMakerTest.java
+++ b/src/test/java/example/_05_singleton/TicketMakerTest.java
@@ -1,0 +1,64 @@
+package example._05_singleton;
+
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TestMethodOrder(value = OrderAnnotation.class)
+class TicketMakerTest {
+
+
+    @Order(1)
+    @Test
+    void instanceIsSingleton() {
+        //given
+        var obj1 = ticketMaker();
+        var obj2 = ticketMaker();
+
+        //then
+        assertThat(obj1).isSameAs(obj2);
+    }
+
+    @Order(2)
+    @Test
+    void instanceIsNotNull() {
+        //given
+        var instance = ticketMaker();
+
+        //then
+        assertThat(instance).isNotNull();
+    }
+
+    @Order(3)
+    @Test
+    void initialTicketNumber() {
+        //given
+        var ticketMaker = ticketMaker();
+
+        //when
+        var initial = ticketMaker.getNextTicketNumber();
+
+        //then
+        assertThat(initial).isEqualTo(1000);
+    }
+
+    @Order(4)
+    @Test
+    void nextTicketNumberIncreasesOne() {
+        //given
+        var ticketMaker = ticketMaker();
+
+        //when
+        var next = ticketMaker.getNextTicketNumber();
+
+        //then
+        assertThat(next).isEqualTo(1001);
+    }
+
+    private TicketMaker ticketMaker() {
+        return TicketMaker.getInstance();
+    }
+}

--- a/src/test/java/example/_05_singleton/TicketMakerTest.java
+++ b/src/test/java/example/_05_singleton/TicketMakerTest.java
@@ -1,12 +1,10 @@
 package example._05_singleton;
 
+import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
-import org.junit.jupiter.api.Order;
-import org.junit.jupiter.api.RepeatedTest;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestMethodOrder;
 
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
@@ -15,34 +13,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 @TestMethodOrder(value = OrderAnnotation.class)
 class TicketMakerTest {
 
+    private final TicketMaker ticketMaker = ticketMaker();
 
     @Order(1)
     @Test
-    void instanceIsSingleton() {
-        //given
-        var obj1 = ticketMaker();
-        var obj2 = ticketMaker();
-
-        //then
-        assertThat(obj1).isSameAs(obj2);
-    }
-
-    @Order(2)
-    @Test
-    void instanceIsNotNull() {
-        //given
-        var instance = ticketMaker();
-
-        //then
-        assertThat(instance).isNotNull();
-    }
-
-    @Order(3)
-    @Test
     void initialTicketNumber() {
-        //given
-        var ticketMaker = ticketMaker();
-
         //when
         var initial = ticketMaker.getNextTicketNumber();
 
@@ -50,31 +25,45 @@ class TicketMakerTest {
         assertThat(initial).isEqualTo(1000);
     }
 
-    @Order(4)
+    @Test
+    void instanceIsSingleton() {
+        //given
+        var other = ticketMaker();
+
+        //then
+        assertThat(ticketMaker).isSameAs(other);
+    }
+
     @Test
     void nextTicketNumberIncreasesOne() {
         //given
-        var ticketMaker = ticketMaker();
+        var previous = ticketMaker.getNextTicketNumber();
 
         //when
-        var next = ticketMaker.getNextTicketNumber();
+        var ticketNumber = ticketMaker.getNextTicketNumber();
 
         //then
-        assertThat(next).isEqualTo(1001);
+        assertThat(ticketNumber).isEqualTo(previous + 1);
     }
 
-    @RepeatedTest(value = 10000, name = "{currentRepetition} / {totalRepetitions}")
-    void multiThreads() throws ExecutionException, InterruptedException {
-        //given
-        var execution = Executors.newFixedThreadPool(2);
+    @Nested
+    class WhenConcurrency {
+        private final ExecutorService executor = Executors.newFixedThreadPool(2);
 
-        //when
-        Future<Integer> ticketNumber = execution.submit(() -> ticketMaker().getNextTicketNumber());
-        Future<Integer> other = execution.submit(() -> ticketMaker().getNextTicketNumber());
+        @RepeatedTest(value = 10_000, name = "{currentRepetition} / {totalRepetitions}")
+        void multiThreads() throws ExecutionException, InterruptedException {
+            //when
+            Future<Integer> ticketNumber = executor.submit(ticketMaker::getNextTicketNumber);
+            Future<Integer> other = executor.submit(ticketMaker::getNextTicketNumber);
 
-        //then
-        assertThat(ticketNumber.get()).isNotEqualTo(other.get());
-        execution.shutdownNow(); // todo: 자리가 안좋아
+            //then
+            assertThat(ticketNumber.get()).isNotEqualTo(other.get());
+        }
+
+        @AfterEach
+        void tearDown() {
+            executor.shutdownNow();
+        }
     }
 
     private TicketMaker ticketMaker() {

--- a/src/test/java/example/_05_singleton/TicketMakerTest.java
+++ b/src/test/java/example/_05_singleton/TicketMakerTest.java
@@ -2,8 +2,13 @@ package example._05_singleton;
 
 import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
 import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -56,6 +61,20 @@ class TicketMakerTest {
 
         //then
         assertThat(next).isEqualTo(1001);
+    }
+
+    @RepeatedTest(value = 10000, name = "{currentRepetition} / {totalRepetitions}")
+    void multiThreads() throws ExecutionException, InterruptedException {
+        //given
+        var execution = Executors.newFixedThreadPool(2);
+
+        //when
+        Future<Integer> ticketNumber = execution.submit(() -> ticketMaker().getNextTicketNumber());
+        Future<Integer> other = execution.submit(() -> ticketMaker().getNextTicketNumber());
+
+        //then
+        assertThat(ticketNumber.get()).isNotEqualTo(other.get());
+        execution.shutdownNow(); // todo: 자리가 안좋아
     }
 
     private TicketMaker ticketMaker() {

--- a/src/test/java/example/_05_singleton/TripleTest.java
+++ b/src/test/java/example/_05_singleton/TripleTest.java
@@ -1,0 +1,27 @@
+package example._05_singleton;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+class TripleTest {
+
+    @Test
+    void singleton() {
+        assertAll(
+                () -> assertThat(Triple.ALPHA).isSameAs(Triple.ALPHA),
+                () -> assertThat(Triple.BETA).isSameAs(Triple.BETA),
+                () -> assertThat(Triple.GAMMA).isSameAs(Triple.GAMMA)
+        );
+    }
+
+    @Test
+    void getInstance() {
+        assertAll(
+                () -> assertThat(Triple.getInstance("ALPHA")).isSameAs(Triple.ALPHA),
+                () -> assertThat(Triple.getInstance("BETA")).isSameAs(Triple.BETA),
+                () -> assertThat(Triple.getInstance("GAMMA")).isSameAs(Triple.GAMMA)
+        );
+    }
+}

--- a/src/test/java/example/_05_singleton/WrongSingletonTest.java
+++ b/src/test/java/example/_05_singleton/WrongSingletonTest.java
@@ -1,0 +1,65 @@
+package example._05_singleton;
+
+import org.assertj.core.util.VisibleForTesting;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.RepeatedTest;
+
+import java.util.HashSet;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class WrongSingletonTest {
+
+    private final int NUMBER_OF_THREADS = 2;
+    private final ExecutorService executor = Executors.newFixedThreadPool(NUMBER_OF_THREADS);
+
+    @RepeatedTest(value = 1000, name = "{currentRepetition} / {totalRepetitions}")
+    void testSingleInstanceCreationInConcurrency() throws InterruptedException {
+        //given
+        var holder = new HashSet<WrongSingleton>();
+        var countDownLatch = new CountDownLatch(NUMBER_OF_THREADS);
+
+        //when
+        for (int i = 0; i < NUMBER_OF_THREADS; i++) {
+            executor.execute(() -> {
+                holder.add(WrongSingleton.getInstance());
+                countDownLatch.countDown();
+            });
+        }
+        countDownLatch.await();
+
+        //then
+        assertThat(holder.size()).isOne();
+    }
+
+    @AfterEach
+    void tearDown() {
+        executor.shutdownNow();
+        WrongSingleton.clearInstance();
+    }
+
+    private static final class WrongSingleton {
+
+        private static WrongSingleton instance = null;
+
+        private WrongSingleton() {
+            System.out.println("인스턴스를 생성했습니다.");
+        }
+
+        static WrongSingleton getInstance() {
+            if (instance == null) {
+                instance = new WrongSingleton();
+            }
+
+            return instance;
+        }
+
+        @VisibleForTesting
+        static void clearInstance() {
+            instance = null;
+        }
+    }
+}

--- a/src/test/java/example/_05_singleton/WrongSingletonTest.java
+++ b/src/test/java/example/_05_singleton/WrongSingletonTest.java
@@ -40,7 +40,7 @@ class WrongSingletonTest {
             System.out.println("인스턴스를 생성했습니다.");
         }
 
-        static WrongSingleton getInstance() {
+        static synchronized WrongSingleton getInstance() {
             if (instance == null) {
                 instance = new WrongSingleton();
             }


### PR DESCRIPTION
> 📚
> 인스턴스가 하나만 존재하는 것을 보증하는 패턴


<img width="688" alt="image" src="https://user-images.githubusercontent.com/75404713/213904260-50eccf38-f868-4d30-9139-188ad4dce2d3.png">


### 메모

- 책에선 [static 필드 사용](https://github.com/viiviii/java-learning-design-patterns/blob/7c0e83c0433322f20bfef1373138ff685b277a63/src/main/java/example/_05_singleton/Singleton.java#L4), [enum 사용](https://github.com/viiviii/java-learning-design-patterns/blob/7c0e83c0433322f20bfef1373138ff685b277a63/src/main/java/example/_05_singleton/Triple.java), [지연 초기화(synchronized 메서드 사용)](https://github.com/viiviii/java-learning-design-patterns/blob/7c0e83c0433322f20bfef1373138ff685b277a63/src/test/java/example/_05_singleton/WrongSingletonTest.java#L43-L49)로 구현한 방법을 소개함
  - 이밖에도 static inner class, volatile 키워드 사용, 더블 체킹 등 다양한 방법이 있는 것 같음
- 명확한 이유가 없다면 지연 초기화를 사용하지 않고 [Singleton.class](https://github.com/viiviii/java-learning-design-patterns/blob/7c0e83c0433322f20bfef1373138ff685b277a63/src/main/java/example/_05_singleton/Singleton.java#L4)처럼 초기화하는 것이 무난하다고 함

### 느낀점

- 테스트가 어렵다
- [getNextTicketNumber](https://github.com/viiviii/java-learning-design-patterns/blob/7c0e83c0433322f20bfef1373138ff685b277a63/src/main/java/example/_05_singleton/TicketMaker.java#L15)와 같은 메서드도 주의해서 구현하자
- 이펙티브 자바에서 싱글톤 내용이 나오는 것 같은데 구현할 일 생기면 함께 읽어보자